### PR TITLE
🔧 Fix Cloud Run service tags naming

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -127,7 +127,7 @@ jobs:
             --set-secrets=DJANGO_SECRET_KEY=DJANGO_SECRET_KEY:latest,REDIS_URL=REDIS_URL:latest,ENCRYPTION_KEY=ENCRYPTION_KEY:latest,DB_HOST=DB_HOST:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,DB_NAME=DB_NAME:latest,CORS_ALLOWED_ORIGINS=CORS_ALLOWED_ORIGINS:latest \
             --set-env-vars=DJANGO_SETTINGS_MODULE=botbalance.settings.prod \
             --memory=512Mi --cpu=1 --concurrency=40 --min-instances=1 \
-            --tag=${{ steps.version.outputs.VERSION }}
+            --tag=$(echo ${{ steps.version.outputs.VERSION }} | sed 's/\./-/g')
 
       - name: 🔄 Deploy Celery Worker
         run: |
@@ -142,7 +142,7 @@ jobs:
             --memory=512Mi --cpu=1 --concurrency=1 --min-instances=1 --max-instances=3 \
             --no-cpu-throttling \
             --command=python --args="worker_entrypoint.py" \
-            --tag=${{ steps.version.outputs.VERSION }}
+            --tag=$(echo ${{ steps.version.outputs.VERSION }} | sed 's/\./-/g')
 
       - name: ✅ Health check
         run: |


### PR DESCRIPTION
- Replace dots with dashes in service tags
- v1.0.0 → --tag=v1-0-0 (GCP compliant)
- Fixes: spec.traffic.tag Resource name error