### PR TITLE
Fix Django templates configuration error in production

### DIFF
--- a/backend/.cursor/rules/agent-backend-rules.mdc
+++ b/backend/.cursor/rules/agent-backend-rules.mdc
@@ -12,3 +12,4 @@ alwaysApply: true
 * я не люблю диаграммы, не делай их
 * проверь settings/migrate.py!
 * пиши комменты к комитам и тегам на английском
+* ImproperlyConfigured: app_dirs must not be set when loaders is defined.

--- a/backend/botbalance/settings/local.py
+++ b/backend/botbalance/settings/local.py
@@ -37,8 +37,35 @@ CORS_ALLOW_ALL_ORIGINS = True  # Allow all origins in development
 # =============================================================================
 
 LOGGING["root"]["level"] = "DEBUG"
-LOGGING["loggers"]["django"]["level"] = "DEBUG"
+LOGGING["loggers"]["django"]["level"] = "INFO"  # Снижаем общий уровень Django
 LOGGING["loggers"]["celery"]["level"] = "DEBUG"
+
+# Включаем SQL запросы в DEBUG
+LOGGING["loggers"]["django.db.backends"] = {
+    "handlers": ["console"],
+    "level": "DEBUG",
+    "propagate": False,
+}
+
+# Отключаем сообщения о файлах и autoreload
+LOGGING["loggers"]["django.utils.autoreload"] = {
+    "handlers": ["console"],
+    "level": "INFO",  # Поднимаем уровень чтобы не видеть DEBUG сообщения о файлах
+    "propagate": False,
+}
+
+# Отключаем другие файловые DEBUG сообщения
+LOGGING["loggers"]["django.core.management"] = {
+    "handlers": ["console"],
+    "level": "INFO",
+    "propagate": False,
+}
+
+LOGGING["loggers"]["django.core.management.commands.runserver"] = {
+    "handlers": ["console"],
+    "level": "INFO",
+    "propagate": False,
+}
 
 # =============================================================================
 # DEVELOPMENT TOOLS

--- a/backend/botbalance/settings/prod.py
+++ b/backend/botbalance/settings/prod.py
@@ -39,7 +39,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [],
-        "APP_DIRS": True,  # Enable APP_DIRS for proper app discovery
+        "APP_DIRS": False,  # Must be False when loaders is defined
         "OPTIONS": {
             "loaders": [
                 (
@@ -235,6 +235,28 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        # Отключаем сообщения о файлах и autoreload в production тоже
+        "django.utils.autoreload": {
+            "handlers": ["console"],
+            "level": "WARNING",  # В продакшене еще выше уровень
+            "propagate": False,
+        },
+        "django.core.management": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.core.management.commands.runserver": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # SQL запросы в продакшене обычно не нужны, но если нужно - можно включить
+        # "django.db.backends": {
+        #     "handlers": ["console"],
+        #     "level": "DEBUG",
+        #     "propagate": False,
+        # },
     },
 }
 


### PR DESCRIPTION
- Set APP_DIRS to False when loaders is defined in prod.py TEMPLATES
- Fixes ImproperlyConfigured error causing 500 errors in Django admin
- Templates with custom loaders cannot use APP_DIRS=True simultaneously