### PR TITLE
Fix Redis cache configuration for production login

### DIFF
--- a/backend/botbalance/settings/prod.py
+++ b/backend/botbalance/settings/prod.py
@@ -169,12 +169,6 @@ CACHES = {
         "LOCATION": os.getenv("REDIS_URL", "redis://localhost:6379/1"),
         "KEY_PREFIX": "botbalance",
         "TIMEOUT": 300,
-        "OPTIONS": {
-            "CONNECTION_POOL_KWARGS": {
-                "max_connections": 20,
-                "retry_on_timeout": True,
-            },
-        },
     }
 }
 


### PR DESCRIPTION
- Removed unsupported CONNECTION_POOL_KWARGS from Redis cache config
- Simplified CACHES configuration to use basic Redis settings
- Fixes Django admin login 500 error: 'AbstractConnection.__init__() got unexpected keyword argument'
- Session storage now works correctly with simplified Redis connection